### PR TITLE
修正: 不要なsys.path.append除去とabsolute importへの完全移行

### DIFF
--- a/backend/app/services/evaluator.py
+++ b/backend/app/services/evaluator.py
@@ -9,10 +9,6 @@ from typing import List, Dict, Any, Optional
 import httpx
 from groq import Groq
 
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
-
 from backend.app.models.article import Article
 from backend.app.models.evaluation import Evaluation, AIEvaluationResult
 from backend.app.utils.logger import get_logger, log_execution_time

--- a/backend/app/services/scraper.py
+++ b/backend/app/services/scraper.py
@@ -11,16 +11,13 @@ from urllib.parse import urljoin, quote
 import requests
 from bs4 import BeautifulSoup
 
-from app.models.article import (
+from backend.app.models.article import (
     Article, 
     NoteArticleMetadata as NoteArticleData,  # エイリアスで互換性維持
     ArticleReference
 )
-from app.utils.logger import get_logger, log_execution_time
-from app.utils.rate_limiter import rate_limiter
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+from backend.app.utils.logger import get_logger, log_execution_time
+from backend.app.utils.rate_limiter import rate_limiter
 from config.config import config 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary

- evaluator.pyとscraper.pyから不要なsys.path.appendコードを除去
- 残っていた相対importを絶対importに変換
- uvパッケージ化による自動モジュール解決機能を活用

## 修正内容

1. **evaluator.py**: sys.path.appendとimport sys/osの除去
2. **scraper.py**: sys.path.appendの除去と相対importの絶対importへの変換
   - `from app.models.article` → `from backend.app.models.article`
   - `from app.utils.logger` → `from backend.app.utils.logger`
   - `from app.utils.rate_limiter` → `from backend.app.utils.rate_limiter`

## 技術的詳細

- PR#31でuvパッケージ化が実装されたため、PYTHONPATHの手動設定は不要
- pyproject.tomlでbackendとconfigパッケージが定義済み
- 絶対importによりモジュール解決が自動化

## テスト結果

✅ インポートテスト:
- Daily process import successful
- JSON generator import successful
- Article evaluator import successful
- Scraper import successful
- Database manager import successful

✅ 構文チェックテスト:
- 全てのPythonファイルが正常にコンパイル

✅ パッケージ化確認テスト:
- Backend package imported successfully

## 影響範囲

- 開発環境でのPYTHONPATH設定が不要に
- より標準的なPythonパッケージ構造への完全移行
- コードの可読性と保守性の向上

🤖 Generated with [Claude Code](https://claude.ai/code)